### PR TITLE
dev-libs/apache-arrow: use system xsimd.

### DIFF
--- a/dev-libs/apache-arrow/apache-arrow-4.0.1.ebuild
+++ b/dev-libs/apache-arrow/apache-arrow-4.0.1.ebuild
@@ -41,6 +41,8 @@ S="${WORKDIR}/${P}/cpp"
 
 src_prepare() {
 	sed -e '/SetupCxxFlags/d' -i CMakeLists.txt || die
+	sed -e '/xsimd.*BUNDLED/d' \
+		-i cmake_modules/ThirdpartyToolchain.cmake || die
 	cmake_src_prepare
 }
 


### PR DESCRIPTION
Let CMake use dev-cpp/xsimd::spark-overlay rather than download from
github.

Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Benda Xu <heroxbd@gentoo.org>