### PR TITLE
dev-java/tomcat-embed-core: add java-virtuals/xmlrpc-api dependency.

### DIFF
--- a/dev-java/tomcat-embed-core/tomcat-embed-core-8.5.28-r1.ebuild
+++ b/dev-java/tomcat-embed-core/tomcat-embed-core-8.5.28-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Skeleton command:
@@ -35,7 +35,9 @@ CDEPEND="
 DEPEND="
 	>=virtual/jdk-1.8:*
 	app-arch/unzip
-	!binary? ( ${CDEPEND} )
+	!binary? ( ${CDEPEND}
+		java-virtuals/xmlrpc-api
+	)
 "
 
 RDEPEND="


### PR DESCRIPTION
Otherwise the build fails with
```
!!! ERROR: Package xmlrpc-api was not found!
```

Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Benda Xu <heroxbd@gentoo.org>