### PR TITLE
dev-java/velocity: add java-virtuals/jms dependency.

### DIFF
--- a/dev-java/velocity/velocity-1.7.ebuild
+++ b/dev-java/velocity/velocity-1.7.ebuild
@@ -40,6 +40,7 @@ DEPEND="
 		>=dev-java/log4j-1.2.17:0
 		>=dev-java/werken-xpath-0.9.4:0
 		java-virtuals/servlet-api:4.0
+		java-virtuals/jms
 	)
 "
 


### PR DESCRIPTION
Otherwise the build fails with

```
!!! ERROR: Package jms was not found!
```

Package-Manager: Portage-3.0.18, Repoman-3.0.2
RepoMan-Options: --force
Signed-off-by: Benda Xu <heroxbd@gentoo.org>